### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/frfink/f8e0c890-6d95-4c0f-83eb-2ad386582796/9393d1cd-a996-401c-982b-0eaedb6899dc/_apis/work/boardbadge/0b3e4e59-a591-494f-9c37-3d59d85ea125)](https://dev.azure.com/frfink/f8e0c890-6d95-4c0f-83eb-2ad386582796/_boards/board/t/9393d1cd-a996-401c-982b-0eaedb6899dc/Microsoft.RequirementCategory)
 # public-repo
 Test public repo for ffink-test account.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/frfink/f8e0c890-6d95-4c0f-83eb-2ad386582796/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.